### PR TITLE
Fixed compatibility issues with bchlib==0.7 and python3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.bin
 venv/*
 .venv/*
+python39/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ optional arguments:
                         Output dump file
   -c CONFIG, --config CONFIG
                         Configuration file
-  -m MODE, --mode MODE  Vendor specific NAND mode (ATMEL, NXP_IMX28
+  -m MODE, --mode MODE  Vendor specific NAND mode (ATMEL, NXP_IMX28, NXP_P1014, YAFFS2 [experimental])
   --atmel-config        Retrieve ATMEL config from first page of the dump file
   --nxp-fcb-config      Retrieve NXP config from firmware control block (FCB) of first page of the dump file
 ```
@@ -101,14 +101,14 @@ The configuration of the ATMEL target system is read from the dump itself (PMECC
 
 ```
 $ ./nand_dump_decoder.sh -i ~/dump/SAMA5D4/dump1 -o sama.bin --atmel-config
- _   _   ___   _   _______  ______                        ______                   _                                                                                                                                
-| \ | | / _ \ | \ | |  _  \ |  _  \                       |  _  \                 | |                                                                                                                               
-|  \| |/ /_\ \|  \| | | | | | | | |_   _ _ __ ___  _ __   | | | |___  ___ ___   __| | ___ _ __                                                                                                                      
-| . ` ||  _  || . ` | | | | | | | | | | | '_ ` _ \| '_ \  | | | / _ \/ __/ _ \ / _` |/ _ \ '__|                                                                                                                     
-| |\  || | | || |\  | |/ /  | |/ /| |_| | | | | | | |_) | | |/ /  __/ (_| (_) | (_| |  __/ |                                                                                                                        
-\_| \_/\_| |_/\_| \_/___/   |___/  \__,_|_| |_| |_| .__/  |___/ \___|\___\___/ \__,_|\___|_|                                                                                                                        
-                                                  | |                                                                                                                                                               
-                                                  |_|                                                                                                                                                               
+ _   _   ___   _   _______  ______                        ______                   _        
+| \ | | / _ \ | \ | |  _  \ |  _  \                       |  _  \                 | |       
+|  \| |/ /_\ \|  \| | | | | | | | |_   _ _ __ ___  _ __   | | | |___  ___ ___   __| | ___ _ __ 
+| . ` ||  _  || . ` | | | | | | | | | | | '_ ` _ \| '_ \  | | | / _ \/ __/ _ \ / _` |/ _ \ '__|
+| |\  || | | || |\  | |/ /  | |/ /| |_| | | | | | | |_) | | |/ /  __/ (_| (_) | (_| |  __/ |
+\_| \_/\_| |_/\_| \_/___/   |___/  \__,_|_| |_| |_| .__/  |___/ \___|\___\___/ \__,_|\___|_|
+                                                  | |                                       
+                                                  |_|                                       
 NAND Dump Decoder v0.2 by Matthias Deeg - SySS GmbH (c) 2018-2020                                        
 ---                                                 
 [*] Found one binary input file (566231040 bytes)                                                        

--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ The NAND Dump Tools can be downloaded and installed in the following way:
 
 ```
 git clone https://github.com/SySS-Research/nand-dump-tools.git
-cd NAND_Dump_Tools
+cd nand-dump-tools
 ./setup.sh
 ```
+
+Note: NAND Dump Tools relies on `bchlib==0.7`, which in turn relies on `pyhon3.19.8`. Install `python3.19.8` for your operating system, after that execute:
+
+```
+python3.9 -m venv venv
+source venv/bin/activate
+pip install -r requirement.txt
+```
+
 
 ## Usage
 

--- a/nand_dump_decoder.py
+++ b/nand_dump_decoder.py
@@ -1256,11 +1256,11 @@ def banner():
 
     print(
 """ _   _   ___   _   _______  ______                        ______                   _           \n"""
-"""| \ | | / _ \ | \ | |  _  \ |  _  \                       |  _  \                 | |          \n"""
-"""|  \| |/ /_\ \|  \| | | | | | | | |_   _ _ __ ___  _ __   | | | |___  ___ ___   __| | ___ _ __ \n"""
-"""| . ` ||  _  || . ` | | | | | | | | | | | '_ ` _ \| '_ \  | | | / _ \/ __/ _ \ / _` |/ _ \ '__|\n"""
-"""| |\  || | | || |\  | |/ /  | |/ /| |_| | | | | | | |_) | | |/ /  __/ (_| (_) | (_| |  __/ |   \n"""
-"""\_| \_/\_| |_/\_| \_/___/   |___/  \__,_|_| |_| |_| .__/  |___/ \___|\___\___/ \__,_|\___|_|   \n"""
+"""| \\ | | / _ \\ | \\ | |  _  \\ |  _  \\                       |  _  \\                 | |          \n"""
+"""|  \\| |/ /_\\ \\|  \\| | | | | | | | |_   _ _ __ ___  _ __   | | | |___  ___ ___   __| | ___ _ __ \n"""
+"""| . ` ||  _  || . ` | | | | | | | | | | | '_ ` _ \\| '_ \\  | | | / _ \\/ __/ _ \\ / _` |/ _ \\ '__|\n"""
+"""| |\\  || | | || |\\  | |/ /  | |/ /| |_| | | | | | | |_) | | |/ /  __/ (_| (_) | (_| |  __/ |   \n"""
+"""\\_| \\_/\\_| |_/\\_| \\_/___/   |___/  \\__,_|_| |_| |_| .__/  |___/ \\___|\\___\\___/ \\__,_|\\___|_|   \n"""
 """                                                  | |                                          \n"""
 """                                                  |_|                                          \n"""
 """NAND Dump Decoder v{0} by Matthias Deeg - SySS GmbH (c) 2018-2020\n---""".format(__version__))
@@ -1282,7 +1282,8 @@ if __name__ == '__main__':
 
     # init argument parser
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--infolder', type=str, help='Input folder with binary dump files (.bin)', required=True)
+    parser.add_argument('-I', '--infolder', type=str, help='Input folder with binary dump files (.bin)', required=False)
+    parser.add_argument('-i', '--infile', type=str, help='Input binary dump file (.bin)', required=False)
     parser.add_argument('-o', '--outfile', type=str, help='Output dump file', required=True)
     parser.add_argument('-c', '--config', type=str, help='Configuration file')
     parser.add_argument('-m', '--mode', type=str, help='Vendor specific NAND mode (ATMEL, NXP_IMX28, NXP_P1014, YAFFS2 [experimental])')
@@ -1297,13 +1298,15 @@ if __name__ == '__main__':
 
     # check if input folder contains binary dump files (.bin)
     input_files = []
-    for e in os.listdir(args.infolder):
-        if os.path.splitext(e)[1] == DUMP_FILE_EXTENSION:
-            input_files.append(os.path.normpath("{}/{}"
-                               .format(args.infolder, e)))
+    if args.infolder is not None:
+        for e in os.listdir(args.infolder):
+            if os.path.splitext(e)[1] == DUMP_FILE_EXTENSION:
+                input_files.append(os.path.normpath(f"{args.infolder}/{e}"))
+    elif args.infile is not None:
+        input_files.append(os.path.normpath(f"{args.infile}"))
 
     if len(input_files) == 0:
-        print("[-] The input folder does not contain any binary dump files (.bin)")
+        print("[-] Input required.")
 
     # only process process input files of the same size
     # the first binary file in the folder is our reference file
@@ -1373,9 +1376,14 @@ if __name__ == '__main__':
 
     else:
         # read configuration from given config file
-        if not os.path.isfile(args.config):
+        try:
+            if not os.path.isfile(args.config):
+              print("[-] Error: Config file '{}' does not exist".format(args.config))
+              sys.exit(1)
+        except:
             print("[-] Error: Config file '{}' does not exist".format(args.config))
             sys.exit(1)
+
 
         print("[*] Read configuration file '{}'".format(args.config))
         configfile = configparser.ConfigParser()

--- a/nand_dump_decoder.sh
+++ b/nand_dump_decoder.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 script_dir=$(cd $(dirname $0); pwd -P)
-. "${script_dir}/.venv/bin/activate"
+source "${script_dir}/venv/bin/activate"
 "${script_dir}/nand_dump_decoder.py" "$@"

--- a/nand_dump_encoder.sh
+++ b/nand_dump_encoder.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 script_dir=$(cd $(dirname $0); pwd -P)
-. "${script_dir}/.venv/bin/activate"
+source "${script_dir}/venv/bin/activate"
 "${script_dir}/nand_dump_encoder.py" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bchlib>=0.7
+bchlib==0.7

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 script_dir=$(cd $(dirname $0); pwd -P)
 cd ${script_dir}
-virtualenv -p python3 .venv
-. ./.venv/bin/activate
+python3.9 -m venv venv
+source ./venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
- Newer versions of bchlib use another constructor interface
- Fixed it by using fixed version of bchlib == 0.7
- This in turn requires python3.9 to be used.
- Updated the README with new instructions
- added error handling and an option to input single files (as it has been described in the README)